### PR TITLE
Add a Powercord manifest for metadata

### DIFF
--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "Purplous",
+    "description": "Purplous is a Discord theme for people who like purple!",
+    "version": "Auto Updating",
+    "author": "Equity",
+    "theme": "import.css",
+    "consent": "false",
+    "license": "Blue Oak Model License - Version 1.0.0"
+}


### PR DESCRIPTION
Currently, a user will have to make their own `powercord_manifest.json` to use this theme within Powercord, this PR creates one. Let me know if you want any info in it changed.