### PR TITLE
import.css: remove vague license grant

### DIFF
--- a/import.css
+++ b/import.css
@@ -6,9 +6,6 @@ Purplous • A purple discord theme
 Repository -> https://github.com/Equity/Purplous
 License    -> Blue Oak Model License 1.0.0
 
-
-Feel free to do whatever you like with my theme, i really don't care.
-
 P.S: I assume your discord theme is dark.
 */
 


### PR DESCRIPTION
Sentences such as "do whatever you like with my theme" can be interpreted as a license grant, conflicting with the actual license.